### PR TITLE
feat: implement GOV.UK-styled error pages

### DIFF
--- a/src/server/common/helpers/errors.js
+++ b/src/server/common/helpers/errors.js
@@ -1,20 +1,33 @@
 import { statusCodes } from '../constants/status-codes.js'
 
-function statusCodeMessage(statusCode) {
+/**
+ * Get user-friendly heading for error status codes
+ * Following GOV.UK Design System guidance - no technical jargon or error codes
+ * @param {number} statusCode - HTTP status code
+ * @returns {string} User-friendly error heading
+ */
+function getErrorHeading(statusCode) {
   switch (statusCode) {
     case statusCodes.notFound:
       return 'Page not found'
     case statusCodes.forbidden:
-      return 'Forbidden'
+      return 'Access denied'
     case statusCodes.unauthorized:
-      return 'Unauthorized'
+      return 'Sign in required'
     case statusCodes.badRequest:
-      return 'Bad Request'
+      return 'Bad request'
     default:
-      return 'Something went wrong'
+      return 'Sorry, there is a problem with the service'
   }
 }
 
+/**
+ * Hapi onPreResponse extension to catch and render error pages
+ * Follows GOV.UK Design System error page patterns
+ * @param {object} request - Hapi request object
+ * @param {object} h - Hapi response toolkit
+ * @returns {object} Rendered error view or continue
+ */
 export function catchAll(request, h) {
   const { response } = request
 
@@ -23,7 +36,7 @@ export function catchAll(request, h) {
   }
 
   const statusCode = response.output.statusCode
-  const errorMessage = statusCodeMessage(statusCode)
+  const heading = getErrorHeading(statusCode)
 
   if (statusCode >= statusCodes.internalServerError) {
     request.logger.error(response?.stack)
@@ -31,9 +44,9 @@ export function catchAll(request, h) {
 
   return h
     .view('error/index', {
-      pageTitle: errorMessage,
-      heading: statusCode,
-      message: errorMessage
+      pageTitle: heading,
+      heading,
+      statusCode
     })
     .code(statusCode)
 }

--- a/src/server/common/helpers/errors.test.js
+++ b/src/server/common/helpers/errors.test.js
@@ -27,6 +27,25 @@ describe('#errors', () => {
     )
     expect(statusCode).toBe(statusCodes.notFound)
   })
+
+  test('Should display GOV.UK compliant 404 content', async () => {
+    const { result } = await server.inject({
+      method: 'GET',
+      url: '/non-existent-path'
+    })
+
+    expect(result).toEqual(
+      expect.stringContaining(
+        'If you typed the web address, check it is correct.'
+      )
+    )
+    expect(result).toEqual(
+      expect.stringContaining(
+        'If you pasted the web address, check you copied the entire address.'
+      )
+    )
+    expect(result).toEqual(expect.stringContaining('return to the home page'))
+  })
 })
 
 describe('#catchAll', () => {
@@ -50,77 +69,99 @@ describe('#catchAll', () => {
     code: mockToolkitCode.mockReturnThis()
   }
 
-  test('Should provide expected "Not Found" page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('Should provide expected "Page not found" page for 404', () => {
     catchAll(mockRequest(statusCodes.notFound), mockToolkit)
 
     expect(mockErrorLogger).not.toHaveBeenCalledWith(mockStack)
     expect(mockToolkitView).toHaveBeenCalledWith(errorPage, {
       pageTitle: 'Page not found',
-      heading: statusCodes.notFound,
-      message: 'Page not found'
+      heading: 'Page not found',
+      statusCode: statusCodes.notFound
     })
     expect(mockToolkitCode).toHaveBeenCalledWith(statusCodes.notFound)
   })
 
-  test('Should provide expected "Forbidden" page', () => {
+  test('Should provide expected "Access denied" page for 403', () => {
     catchAll(mockRequest(statusCodes.forbidden), mockToolkit)
 
     expect(mockErrorLogger).not.toHaveBeenCalledWith(mockStack)
     expect(mockToolkitView).toHaveBeenCalledWith(errorPage, {
-      pageTitle: 'Forbidden',
-      heading: statusCodes.forbidden,
-      message: 'Forbidden'
+      pageTitle: 'Access denied',
+      heading: 'Access denied',
+      statusCode: statusCodes.forbidden
     })
     expect(mockToolkitCode).toHaveBeenCalledWith(statusCodes.forbidden)
   })
 
-  test('Should provide expected "Unauthorized" page', () => {
+  test('Should provide expected "Sign in required" page for 401', () => {
     catchAll(mockRequest(statusCodes.unauthorized), mockToolkit)
 
     expect(mockErrorLogger).not.toHaveBeenCalledWith(mockStack)
     expect(mockToolkitView).toHaveBeenCalledWith(errorPage, {
-      pageTitle: 'Unauthorized',
-      heading: statusCodes.unauthorized,
-      message: 'Unauthorized'
+      pageTitle: 'Sign in required',
+      heading: 'Sign in required',
+      statusCode: statusCodes.unauthorized
     })
     expect(mockToolkitCode).toHaveBeenCalledWith(statusCodes.unauthorized)
   })
 
-  test('Should provide expected "Bad Request" page', () => {
+  test('Should provide expected "Bad request" page for 400', () => {
     catchAll(mockRequest(statusCodes.badRequest), mockToolkit)
 
     expect(mockErrorLogger).not.toHaveBeenCalledWith(mockStack)
     expect(mockToolkitView).toHaveBeenCalledWith(errorPage, {
-      pageTitle: 'Bad Request',
-      heading: statusCodes.badRequest,
-      message: 'Bad Request'
+      pageTitle: 'Bad request',
+      heading: 'Bad request',
+      statusCode: statusCodes.badRequest
     })
     expect(mockToolkitCode).toHaveBeenCalledWith(statusCodes.badRequest)
   })
 
-  test('Should provide expected default page', () => {
+  test('Should provide expected default page for unknown status codes', () => {
     catchAll(mockRequest(statusCodes.imATeapot), mockToolkit)
 
     expect(mockErrorLogger).not.toHaveBeenCalledWith(mockStack)
     expect(mockToolkitView).toHaveBeenCalledWith(errorPage, {
-      pageTitle: 'Something went wrong',
-      heading: statusCodes.imATeapot,
-      message: 'Something went wrong'
+      pageTitle: 'Sorry, there is a problem with the service',
+      heading: 'Sorry, there is a problem with the service',
+      statusCode: statusCodes.imATeapot
     })
     expect(mockToolkitCode).toHaveBeenCalledWith(statusCodes.imATeapot)
   })
 
-  test('Should provide expected "Something went wrong" page and log error for internalServerError', () => {
+  test('Should provide service error page and log error for 500', () => {
     catchAll(mockRequest(statusCodes.internalServerError), mockToolkit)
 
     expect(mockErrorLogger).toHaveBeenCalledWith(mockStack)
     expect(mockToolkitView).toHaveBeenCalledWith(errorPage, {
-      pageTitle: 'Something went wrong',
-      heading: statusCodes.internalServerError,
-      message: 'Something went wrong'
+      pageTitle: 'Sorry, there is a problem with the service',
+      heading: 'Sorry, there is a problem with the service',
+      statusCode: statusCodes.internalServerError
     })
     expect(mockToolkitCode).toHaveBeenCalledWith(
       statusCodes.internalServerError
     )
+  })
+
+  test('Should continue for non-Boom responses', () => {
+    const nonBoomRequest = {
+      response: { statusCode: 200 },
+      logger: { error: mockErrorLogger }
+    }
+    const mockContinue = Symbol('continue')
+    const mockToolkitWithContinue = {
+      continue: mockContinue,
+      view: mockToolkitView,
+      code: mockToolkitCode
+    }
+
+    const result = catchAll(nonBoomRequest, mockToolkitWithContinue)
+
+    expect(result).toBe(mockContinue)
+    expect(mockToolkitView).not.toHaveBeenCalled()
   })
 })

--- a/src/server/error/index.njk
+++ b/src/server/error/index.njk
@@ -1,13 +1,33 @@
 {% extends 'layouts/page.njk' %}
 
-{% block content %}
-  {{ appHeading({
-    text: heading
-  }) }}
+{% block beforeContent %}
+  {# No breadcrumbs on error pages as per GOV.UK guidance #}
+{% endblock %}
 
-  <div class="govuk-grid-row">
+{% block content %}
+  <div class="govuk-grid-row govuk-!-margin-top-6">
     <div class="govuk-grid-column-two-thirds">
-      <p>{{ message }}</p>
+      <h1 class="govuk-heading-xl">{{ heading }}</h1>
+
+      {% if statusCode == 404 %}
+        <p class="govuk-body">If you typed the web address, check it is correct.</p>
+        <p class="govuk-body">If you pasted the web address, check you copied the entire address.</p>
+        <p class="govuk-body">You can <a href="/" class="govuk-link">return to the home page</a> or use the search to find what you need.</p>
+      {% elif statusCode == 403 %}
+        <p class="govuk-body">You do not have permission to view this page.</p>
+        <p class="govuk-body">If you think you should have access, contact your administrator.</p>
+        <p class="govuk-body">You can <a href="/" class="govuk-link">return to the home page</a>.</p>
+      {% elif statusCode == 401 %}
+        <p class="govuk-body">You need to sign in to access this page.</p>
+        <p class="govuk-body">You can <a href="/" class="govuk-link">return to the home page</a>.</p>
+      {% elif statusCode == 400 %}
+        <p class="govuk-body">Check the web address and try again.</p>
+        <p class="govuk-body">You can <a href="/" class="govuk-link">return to the home page</a>.</p>
+      {% else %}
+        {# 500 and other server errors #}
+        <p class="govuk-body">Try again later.</p>
+        <p class="govuk-body">You can <a href="/" class="govuk-link">return to the home page</a> and try what you were doing again.</p>
+      {% endif %}
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
## Summary

- Add GOV.UK Design System compliant error pages for common HTTP errors
- User-friendly headings without technical jargon (no error codes like "404")
- Context-appropriate guidance for each error type
- Proper spacing using `govuk-!-margin-top-6` utility class
- No breadcrumbs on error pages (per GOV.UK guidance)

## Error Pages Implemented

| Status Code | Heading | Content |
|-------------|---------|---------|
| 404 | Page not found | Guidance to check URL, link to home |
| 403 | Access denied | Permission message, link to home |
| 401 | Sign in required | Sign in prompt, link to home |
| 400 | Bad request | Check URL guidance, link to home |
| 500+ | Sorry, there is a problem with the service | Try again later message |

## Test plan

- [x] All 128 tests pass
- [x] 100% test coverage for errors.js
- [x] Format and lint checks pass
- [x] GOV.UK Design System patterns followed
- [ ] Visual check: Error pages have proper spacing from header
- [ ] SonarQube quality gate passes

🤖 Generated with [Claude Code](https://claude.ai/code)