### PR TITLE
fix: add content phrase boost for multi-word search queries

### DIFF
--- a/src/server/common/helpers/search-index.js
+++ b/src/server/common/helpers/search-index.js
@@ -16,7 +16,8 @@ const SCORE_WEIGHTS = {
   HEADING_MATCH: 20,
   CONTENT_MATCH: 10,
   TITLE_PHRASE_BOOST: 50,
-  DESCRIPTION_PHRASE_BOOST: 20
+  DESCRIPTION_PHRASE_BOOST: 20,
+  CONTENT_PHRASE_BOOST: 15
 }
 
 const DEFAULT_RESULT_LIMIT = 20
@@ -170,12 +171,17 @@ function calculateEntryScore(entry, queryTerms, queryLower) {
     }
   }
 
-  // Boost exact phrase matches
-  if (titleLower.includes(queryLower)) {
-    score += SCORE_WEIGHTS.TITLE_PHRASE_BOOST
-  }
-  if (descriptionLower.includes(queryLower)) {
-    score += SCORE_WEIGHTS.DESCRIPTION_PHRASE_BOOST
+  // Boost exact phrase matches (multi-word queries appearing together)
+  if (queryTerms.length > 1) {
+    if (titleLower.includes(queryLower)) {
+      score += SCORE_WEIGHTS.TITLE_PHRASE_BOOST
+    }
+    if (descriptionLower.includes(queryLower)) {
+      score += SCORE_WEIGHTS.DESCRIPTION_PHRASE_BOOST
+    }
+    if (contentLower.includes(queryLower)) {
+      score += SCORE_WEIGHTS.CONTENT_PHRASE_BOOST
+    }
   }
 
   return { score, matched }


### PR DESCRIPTION
## Summary

- Adds `CONTENT_PHRASE_BOOST` (15 points) to prioritize pages where multi-word search queries appear as an exact phrase in the content
- Wraps phrase boost logic to only apply for multi-word queries (single-word searches don't benefit from phrase matching)
- Previously, exact phrase matching only worked for title and description - now content is also boosted

## Problem

When searching for two words that appear next to each other in a page's content, those results weren't being prioritized over pages where the words appear separately. For example, searching "service assessment" should prioritize pages containing that exact phrase over pages that just mention "service" and "assessment" in different places.

## Solution

Added a new scoring weight:
- `CONTENT_PHRASE_BOOST: 15` (lower than title boost of 50 and description boost of 20)

The phrase boost hierarchy is now:
1. Title phrase match: +50 points
2. Description phrase match: +20 points  
3. Content phrase match: +15 points

## Test plan

- [x] Added unit tests for phrase boost scoring in `search-index.test.js`
- [x] All 132 tests pass
- [x] Format and lint checks pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)