### PR TITLE
fix: export enabled routes

### DIFF
--- a/src/server/common/helpers/search-index-gated.test.js
+++ b/src/server/common/helpers/search-index-gated.test.js
@@ -1,0 +1,62 @@
+/**
+ * Search index tests with AI content gated off.
+ *
+ * vitest.setup.js sets ENABLE_AI_CONTENT=true so the default suite indexes
+ * everything. This file unsets it, resets the module cache (to drop both the
+ * cached index and the cached config) and dynamically imports the helper,
+ * mirroring the pattern used by src/server/home/controller-gated.test.js.
+ */
+import { describe, test, expect, beforeAll, afterAll, vi } from 'vitest'
+
+describe('Search index with AI content gated off', () => {
+  let buildSearchIndex
+  let searchContent
+  let getSuggestions
+  let previousEnableAiContent
+
+  beforeAll(async () => {
+    previousEnableAiContent = process.env.ENABLE_AI_CONTENT
+    delete process.env.ENABLE_AI_CONTENT
+    vi.resetModules()
+    const mod = await import('./search-index.js')
+    buildSearchIndex = mod.buildSearchIndex
+    searchContent = mod.searchContent
+    getSuggestions = mod.getSuggestions
+  })
+
+  afterAll(() => {
+    if (previousEnableAiContent === undefined) {
+      delete process.env.ENABLE_AI_CONTENT
+    } else {
+      process.env.ENABLE_AI_CONTENT = previousEnableAiContent
+    }
+    vi.resetModules()
+  })
+
+  test('buildSearchIndex excludes /ai-toolkit pages', () => {
+    const index = buildSearchIndex()
+
+    expect(index.length).toBeGreaterThan(0)
+    expect(index.some((e) => e.url.startsWith('/ai-toolkit'))).toBe(false)
+  })
+
+  test('buildSearchIndex still includes non-toolkit pages', () => {
+    const index = buildSearchIndex()
+
+    expect(index.some((e) => e.url === '/accessibility')).toBe(true)
+  })
+
+  test('searchContent does not return /ai-toolkit results', () => {
+    const results = searchContent('prompt')
+
+    expect(results.every((r) => !r.url.startsWith('/ai-toolkit'))).toBe(true)
+  })
+
+  test('getSuggestions does not surface /ai-toolkit results', () => {
+    const suggestions = getSuggestions('prompt')
+
+    expect(suggestions.every((s) => !s.url.startsWith('/ai-toolkit'))).toBe(
+      true
+    )
+  })
+})

--- a/src/server/common/helpers/search-index.js
+++ b/src/server/common/helpers/search-index.js
@@ -4,6 +4,7 @@ import matter from 'gray-matter'
 import { fileURLToPath } from 'node:url'
 
 import { createLogger } from './logging/logger.js'
+import { getEnabledMarkdownRoutes } from '../../markdown-pages/index.js'
 
 const logger = createLogger()
 const dirname = path.dirname(fileURLToPath(import.meta.url))
@@ -101,6 +102,7 @@ function extractHeadings(markdown) {
  */
 export function buildSearchIndex() {
   const markdownFiles = findMarkdownFiles(CONTENT_DIR)
+  const enabledRoutes = new Set(getEnabledMarkdownRoutes())
   const index = []
 
   for (const filePath of markdownFiles) {
@@ -112,6 +114,12 @@ export function buildSearchIndex() {
       // Convert file path to URL path
       // e.g., 'accessibility/manage-accessibility.md' -> '/accessibility/manage-accessibility'
       const url = '/' + filePath.replace(/\.md$/, '')
+
+      // Skip files whose route is not registered (e.g. AI toolkit pages when
+      // aiContent.enabled is false) so search can't surface 404 links.
+      if (!enabledRoutes.has(url)) {
+        continue
+      }
 
       const entry = {
         title: data.title || '',

--- a/src/server/common/helpers/search-index.test.js
+++ b/src/server/common/helpers/search-index.test.js
@@ -51,6 +51,12 @@ describe('#searchIndex', () => {
       expect(entry.content).not.toMatch(/^#{1,6}\s/)
       expect(entry.content).not.toMatch(/\[.*\]\(.*\)/)
     })
+
+    test('should include AI toolkit pages when the flag is enabled', () => {
+      const index = buildSearchIndex()
+
+      expect(index.some((e) => e.url.startsWith('/ai-toolkit'))).toBe(true)
+    })
   })
 
   describe('getSearchIndex', () => {

--- a/src/server/common/helpers/search-index.unit.test.js
+++ b/src/server/common/helpers/search-index.unit.test.js
@@ -49,9 +49,11 @@ describe('#searchIndex error handling', () => {
 
   describe('When a single file fails to read', () => {
     test('Should skip the bad file and continue building the index', () => {
+      // Use filenames that map to real registered routes so the index
+      // filter does not drop them before the read is attempted.
       mockReaddirSync.mockReturnValue([
-        { name: 'good.md', isDirectory: () => false },
-        { name: 'bad.md', isDirectory: () => false }
+        { name: 'accessibility.md', isDirectory: () => false },
+        { name: 'patterns.md', isDirectory: () => false }
       ])
 
       let callCount = 0
@@ -70,7 +72,7 @@ describe('#searchIndex error handling', () => {
       expect(mockLoggerError).toHaveBeenCalledWith(
         expect.objectContaining({
           err: expect.any(Error),
-          filePath: 'bad.md'
+          filePath: 'patterns.md'
         }),
         'Failed to index markdown file, skipping'
       )

--- a/src/server/markdown-pages/index.js
+++ b/src/server/markdown-pages/index.js
@@ -1,14 +1,14 @@
 import { config } from '../../config/config.js'
 import { getMarkdownPage } from './controller.js'
 
-function isAiToolkitRoute(routePath) {
+export function isAiToolkitRoute(routePath) {
   return routePath === '/ai-toolkit' || routePath.startsWith('/ai-toolkit/')
 }
 
 /**
  * Markdown page routes - maps URL paths to markdown files
  */
-const markdownRoutes = [
+export const markdownRoutes = [
   '/accessibility-statement',
   '/service-assessments',
   '/service-assessments/book-an-assessment',
@@ -133,16 +133,23 @@ const markdownRoutes = [
   '/ai-toolkit/from-the-field'
 ]
 
+/**
+ * Returns the list of markdown routes that are currently enabled, applying
+ * the same flag-driven filtering that the plugin uses to register routes.
+ * Shared with the search index so gated content stays out of search results.
+ */
+export function getEnabledMarkdownRoutes() {
+  const aiContentEnabled = config.get('aiContent.enabled')
+  return aiContentEnabled
+    ? markdownRoutes
+    : markdownRoutes.filter((path) => !isAiToolkitRoute(path))
+}
+
 export const markdownPages = {
   plugin: {
     name: 'markdown-pages',
     register: async (server) => {
-      const aiContentEnabled = config.get('aiContent.enabled')
-      const enabledRoutes = aiContentEnabled
-        ? markdownRoutes
-        : markdownRoutes.filter((path) => !isAiToolkitRoute(path))
-
-      const routes = enabledRoutes.map((path) => ({
+      const routes = getEnabledMarkdownRoutes().map((path) => ({
         method: 'GET',
         path,
         handler: getMarkdownPage(`${path.slice(1)}.md`)

--- a/src/server/search/controller-gated.test.js
+++ b/src/server/search/controller-gated.test.js
@@ -1,0 +1,93 @@
+/**
+ * Search controller tests with AI content gated off.
+ *
+ * Mirrors src/server/home/controller-gated.test.js: unset ENABLE_AI_CONTENT,
+ * reset modules, then dynamically import the server so route registration and
+ * the search index both pick up the gated state.
+ */
+import { describe, test, expect, beforeAll, afterAll, vi } from 'vitest'
+import { statusCodes } from '../common/constants/status-codes.js'
+
+describe('Search with AI content gated off', () => {
+  let server
+  let previousEnableAiContent
+
+  beforeAll(async () => {
+    previousEnableAiContent = process.env.ENABLE_AI_CONTENT
+    delete process.env.ENABLE_AI_CONTENT
+    vi.resetModules()
+    const { createServer } = await import('../server.js')
+    server = await createServer()
+    await server.initialize()
+  })
+
+  afterAll(async () => {
+    await server.stop({ timeout: 0 })
+    if (previousEnableAiContent === undefined) {
+      delete process.env.ENABLE_AI_CONTENT
+    } else {
+      process.env.ENABLE_AI_CONTENT = previousEnableAiContent
+    }
+    vi.resetModules()
+  })
+
+  describe('GET /api/search/index', () => {
+    test('returns 200', async () => {
+      const { statusCode } = await server.inject({
+        method: 'GET',
+        url: '/api/search/index'
+      })
+
+      expect(statusCode).toBe(statusCodes.ok)
+    })
+
+    test('does not include any /ai-toolkit entries', async () => {
+      const response = await server.inject({
+        method: 'GET',
+        url: '/api/search/index'
+      })
+
+      const index = JSON.parse(response.payload)
+
+      expect(index.length).toBeGreaterThan(0)
+      expect(index.some((e) => e.url.startsWith('/ai-toolkit'))).toBe(false)
+    })
+
+    test('still includes non-toolkit pages', async () => {
+      const response = await server.inject({
+        method: 'GET',
+        url: '/api/search/index'
+      })
+
+      const index = JSON.parse(response.payload)
+
+      expect(index.some((e) => e.url === '/accessibility')).toBe(true)
+    })
+  })
+
+  describe('GET /api/search/suggestions', () => {
+    test('does not surface /ai-toolkit results', async () => {
+      const response = await server.inject({
+        method: 'GET',
+        url: '/api/search/suggestions?q=prompt'
+      })
+
+      const suggestions = JSON.parse(response.payload)
+
+      expect(suggestions.every((s) => !s.url.startsWith('/ai-toolkit'))).toBe(
+        true
+      )
+    })
+  })
+
+  describe('GET /search', () => {
+    test('does not link to any /ai-toolkit page', async () => {
+      const { result } = await server.inject({
+        method: 'GET',
+        url: '/search?q=prompt'
+      })
+
+      expect(result).not.toEqual(expect.stringContaining('href="/ai-toolkit'))
+    })
+  })
+})


### PR DESCRIPTION
Search is currently driven by a search index based on the frontmatter of the content files, this fix excludes the AI toolkit routes from that search index when the toolkit is not enabled.