### PR TITLE
Enable the AI digital toolkit by default

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -150,9 +150,9 @@ export const config = convict({
   },
   aiContent: {
     enabled: {
-      doc: 'Whether AI content (the AI digital toolkit at /ai-toolkit) is visible. Defaults to false. Set ENABLE_AI_CONTENT=true on each environment that should show the content.',
+      doc: 'Whether AI content (the AI digital toolkit at /ai-toolkit) is visible. Defaults to true (visible in all environments). Set ENABLE_AI_CONTENT=false to hide it in a specific environment.',
       format: Boolean,
-      default: false,
+      default: true,
       env: 'ENABLE_AI_CONTENT'
     }
   },

--- a/src/server/common/helpers/search-index-gated.test.js
+++ b/src/server/common/helpers/search-index-gated.test.js
@@ -1,9 +1,9 @@
 /**
  * Search index tests with AI content gated off.
  *
- * vitest.setup.js sets ENABLE_AI_CONTENT=true so the default suite indexes
- * everything. This file unsets it, resets the module cache (to drop both the
- * cached index and the cached config) and dynamically imports the helper,
+ * aiContent.enabled defaults to true, so the default suite indexes everything.
+ * This file sets ENABLE_AI_CONTENT=false, resets the module cache (to drop both
+ * the cached index and the cached config) and dynamically imports the helper,
  * mirroring the pattern used by src/server/home/controller-gated.test.js.
  */
 import { describe, test, expect, beforeAll, afterAll, vi } from 'vitest'
@@ -16,7 +16,7 @@ describe('Search index with AI content gated off', () => {
 
   beforeAll(async () => {
     previousEnableAiContent = process.env.ENABLE_AI_CONTENT
-    delete process.env.ENABLE_AI_CONTENT
+    process.env.ENABLE_AI_CONTENT = 'false'
     vi.resetModules()
     const mod = await import('./search-index.js')
     buildSearchIndex = mod.buildSearchIndex

--- a/src/server/home/controller-gated.test.js
+++ b/src/server/home/controller-gated.test.js
@@ -1,12 +1,11 @@
 /**
  * Home page and route registration tests with AI content gated off.
  *
- * The gate is config-driven: aiContent.enabled defaults to false unless
- * ENABLE_AI_CONTENT=true is set. The wider test suite has it set to true via
- * vitest.setup.js so the default-on tests pass. This file unsets the env var,
- * resets the module cache, then dynamically imports the server. That keeps the
- * gated state isolated to this file and leaves the rest of the suite running
- * with content visible.
+ * The gate is config-driven: aiContent.enabled defaults to true, and content is
+ * hidden only when ENABLE_AI_CONTENT=false. This file sets it to false, resets
+ * the module cache, then dynamically imports the server. That keeps the gated
+ * state isolated to this file and leaves the rest of the suite running with
+ * content visible.
  */
 import { describe, test, expect, beforeAll, afterAll, vi } from 'vitest'
 import { statusCodes } from '../common/constants/status-codes.js'
@@ -17,7 +16,7 @@ describe('AI content gated off', () => {
 
   beforeAll(async () => {
     previousEnableAiContent = process.env.ENABLE_AI_CONTENT
-    delete process.env.ENABLE_AI_CONTENT
+    process.env.ENABLE_AI_CONTENT = 'false'
     vi.resetModules()
     const { createServer } = await import('../server.js')
     server = await createServer()

--- a/src/server/redirects/redirects.test.js
+++ b/src/server/redirects/redirects.test.js
@@ -1,10 +1,10 @@
 /**
  * Tests for the 301 redirects from old /ai-playbook URLs to /ai-toolkit.
  *
- * The default suite runs with ENABLE_AI_CONTENT=true (vitest.setup.js), so
- * the redirect routes are registered and we can hit them. A second describe
- * block unsets the env var, resets the module cache, and re-imports the
- * server to verify the redirects also disappear when AI content is gated.
+ * AI content is enabled by default, so the redirect routes are registered and
+ * we can hit them. A second describe block sets ENABLE_AI_CONTENT=false, resets
+ * the module cache, and re-imports the server to verify the redirects also
+ * disappear when AI content is gated off.
  */
 import { describe, test, expect, beforeAll, afterAll, vi } from 'vitest'
 import { createServer } from '../server.js'
@@ -88,7 +88,7 @@ describe('301 redirects (AI content gated off)', () => {
 
   beforeAll(async () => {
     previousEnableAiContent = process.env.ENABLE_AI_CONTENT
-    delete process.env.ENABLE_AI_CONTENT
+    process.env.ENABLE_AI_CONTENT = 'false'
     vi.resetModules()
     const { createServer: createServerGated } = await import('../server.js')
     server = await createServerGated()

--- a/src/server/search/controller-gated.test.js
+++ b/src/server/search/controller-gated.test.js
@@ -1,7 +1,7 @@
 /**
  * Search controller tests with AI content gated off.
  *
- * Mirrors src/server/home/controller-gated.test.js: unset ENABLE_AI_CONTENT,
+ * Mirrors src/server/home/controller-gated.test.js: set ENABLE_AI_CONTENT=false,
  * reset modules, then dynamically import the server so route registration and
  * the search index both pick up the gated state.
  */
@@ -14,7 +14,7 @@ describe('Search with AI content gated off', () => {
 
   beforeAll(async () => {
     previousEnableAiContent = process.env.ENABLE_AI_CONTENT
-    delete process.env.ENABLE_AI_CONTENT
+    process.env.ENABLE_AI_CONTENT = 'false'
     vi.resetModules()
     const { createServer } = await import('../server.js')
     server = await createServer()


### PR DESCRIPTION
Flip the aiContent.enabled flag default from false to true so the AI digital toolkit at /ai-toolkit is visible in every environment, including production. ENABLE_AI_CONTENT is kept as a per-environment kill-switch: set it to false to hide the toolkit again without a code change.

- config.js: default false to true, with an updated doc string
- update the four gated tests to set ENABLE_AI_CONTENT=false (rather than unset it) to exercise the off state, since unset now means on

The toolkit, including the redesigned tools radar merged in #126, was already on main behind this flag. All tests pass, and the kill-switch is verified to still hide the routes, nav link, home card, redirects and search entries.