### PR TITLE
Add the delivery groups guidance page

### DIFF
--- a/src/content/delivery-groups/follow-delivery-governance.md
+++ b/src/content/delivery-groups/follow-delivery-governance.md
@@ -1,7 +1,7 @@
 ---
-title: Delivery group governance
+title: Follow delivery guidance
 caption: Delivery groups
-description: The governance model defines how a delivery group will prioritise and deliver work.
+description: This guide explains what digital delivery groups are, why they exist, and how they work in practice with the rest of Defra group.
 layout: two-thirds
 headerServiceName: Digital Defra
 showMainNavigation: true
@@ -10,29 +10,232 @@ breadcrumbs:
     href: /
   - text: Delivery groups
     href: /delivery-groups
-  - text: Delivery group governance
+  - text: Follow delivery guidance
 ---
 
-Delivery group leads should use these frameworks as needed.
+<div class="defra-version-banner">
+  <span class="defra-version-banner__text"><span class="defra-version-banner__label" style="vertical-align: middle">Draft</span> This guide will be updated as we improve our ways of working.</span>
+</div>
 
-The model and assurances should be used to:
+It sets out the minimum expectations and shared principles that delivery groups should be built on.
 
-- deliver [services](https://www.gov.uk/service-manual/service-assessments/what-a-service-is) in an outcome-focused and [agile](https://www.gov.uk/service-manual/agile-delivery) way
-- operate with clarity and consistency
-- work in the open
+Delivery groups should use this guide as a starting point and tailor how they work based on their context, resource and users.
 
----
+## Contents
 
-## Governance
+- [What a delivery group is](#what-a-delivery-group-is)
+- [How delivery groups work](#how-delivery-groups-work)
+- [Who is part of a delivery group](#who-is-part-of-a-delivery-group)
+- [Culture and behaviours](#culture-and-behaviours)
+- [Ownership](#ownership)
+- [How decisions are made](#how-decisions-are-made)
+- [How direction is set](#how-direction-is-set)
+- [How we measure success](#how-we-measure-success)
+- [Assurance: how to stay on track](#assurance-how-to-stay-on-track)
+- [Financial management](#financial-management)
+- [Working across Defra and arm's length bodies](#working-across-defra-and-arms-length-bodies)
+- [Using this guide](#using-this-guide)
+- [Next steps](#next-steps)
 
-How a delivery group is structured and who is needed to deliver outcomes.
+<span id="what-a-delivery-group-is"></span>
 
-[View the governance model](/delivery-groups/follow-delivery-governance/governance-model)
+## What a delivery group is
 
----
+A delivery group is a structured way of delivering Defra's outcomes using digital, data and technology.
 
-## Assurance
+They exist to:
 
-How we ensure quality, follow best practice and mitigate risk.
+- provide a consistent group of digital experts to support the delivery of a set of policy outcomes
+- work in partnership with business areas, using that consistency to build confidence and trust
+- support the full end to end of service delivery, from policy to operations and from conception to live
 
-[Read the list of assurances](/delivery-groups/follow-delivery-governance/assurance)
+Policy teams set the outcomes we want to achieve. Operational teams own and run the services that deliver those outcomes day to day. Delivery groups provide multidisciplinary digital teams to design, build and continuously improve those services.
+
+<span id="how-delivery-groups-work"></span>
+
+## How delivery groups work
+
+Delivery groups are designed to support fast learning, safe decision making and continuous improvement. The delivery group [governance model](/delivery-groups/follow-delivery-governance/governance-model) defines how each level and function supports a delivery group.
+
+In practice, this means:
+
+- working in small, multidisciplinary teams (typically around 10 people) within a wider portfolio
+- taking an [agile](https://www.gov.uk/service-manual/agile-delivery/agile-government-services-introduction) approach, delivering value early and learning as we go
+- empowering people to make decisions as part of their roles
+- using data, user insight and evidence to make informed decisions
+- working transparently, using different tools to share progress
+- access to the right digital expertise and tools
+
+Structure and governance should reflect the context in which each delivery group operates. They should enable delivery, not slow it down.
+
+<span id="who-is-part-of-a-delivery-group"></span>
+
+## Who is part of a delivery group
+
+A delivery group is primarily made up of digital professionals. Roles are described by using the [Government Digital and Data Profession Capability Framework (GDAD)](https://ddat-capability-framework.service.gov.uk/).
+
+Delivery group funding should be directed towards creating and maintaining stable teams. These teams should ideally be aligned to services, if not digital products.
+
+Funding should not be organised around short lived projects – this results in waste and loss of knowledge as teams are regularly built and disbanded.
+
+Teams should be made up of permanent civil servants, where possible. This creates the stability and longevity needed to make sure a delivery group carries and shares knowledge over time.
+
+Typical functions in a delivery group:
+
+- business leadership
+- product management
+- delivery management
+- user centred design
+- performance and insight
+- technology and security
+- operations and support
+
+Delivery groups should publish who is working as part of the delivery group and how they are organised.
+
+<span id="culture-and-behaviours"></span>
+
+## Culture and behaviours
+
+Everyone should feel happy and supported at work. People should feel like they are actively contributing to meet outcomes as part of their team.
+
+Delivery groups should work together to ensure people:
+
+- have a positive work/life balance
+- are trusted to make decisions and deliver outcomes
+- feel safe to constructively challenge
+- have room to test, fail and iterate
+- contribute to a culture of learning and feedback
+- work as one team, and don't simply 'hand-off' between professions
+
+When a delivery group changes how it works, they should plan transparently, consult those affected and communicate early.
+
+<span id="ownership"></span>
+
+## Ownership
+
+Clear ownership is essential for effective delivery and accountability.
+
+This means that:
+
+- outcomes are owned by policy or arm's length bodies
+- digital delivery is owned by the delivery group
+- services have clear, named service owners
+- products and delivery approaches support those services
+
+Delivery groups are expected to take responsibility for the full digital lifecycle of what they deliver. This means:
+
+- continuously improving and sustaining live services
+- managing legacy systems and technical debt
+- owning static and dynamic content, including tackling content debt
+- ensuring delivery is user-centred and accessible
+
+<span id="how-decisions-are-made"></span>
+
+## How decisions are made
+
+Decisions should be made at the most appropriate level across the delivery group. This is detailed in [the governance model](/delivery-groups/follow-delivery-governance/governance-model). This means:
+
+- strategic roles set outcomes and decide how to allocate the delivery group's resources
+- co-ordination roles plan and support the people delivering the work
+- those implementing the strategy make decisions on how to deliver the work
+
+Taking this approach means a delivery group can deliver faster and with clear accountability.
+
+<span id="how-direction-is-set"></span>
+
+## How direction is set
+
+Strategic leads work together to set the direction of a delivery group:
+
+- senior business leads are responsible for setting the outcomes the delivery group is trying to achieve
+- the delivery group lead is responsible for deciding what the delivery group needs to do to achieve those outcomes
+
+Decisions should be made based on evidence and insight. To make the direction clear, a delivery group should publish:
+
+- the outcomes they are trying to achieve and how they measure success against them
+- a strategic roadmap, which should link to more detailed service roadmaps
+- objectives and key results (OKRs) or equivalent outcome focused measures
+- an overview of services owned within the delivery group
+- a pipeline of in progress and upcoming work
+
+<span id="how-we-measure-success"></span>
+
+## How we measure success
+
+Success is measured by impact against outcomes, not just milestones delivered. It allows delivery groups to learn and improve – it is not a compliance exercise.
+
+Delivery groups set their own measures of success and use performance data and user insight to guide decisions.
+
+This means they can track benefits and outcomes over time, and stop or change work that isn't delivering value.
+
+<span id="assurance-how-to-stay-on-track"></span>
+
+## Assurance: how to stay on track
+
+[Assurance](/delivery-groups/follow-delivery-governance/assurance) helps delivery groups spot problems early and act on them quicker. They build confidence that the delivery group is moving in the right direction.
+
+All delivery groups must use:
+
+- spend controls (where applicable)
+- service assessments at key points
+- operational service readiness before going live
+
+Transactional services are also measured against [the service standard](https://www.gov.uk/service-manual/service-standard).
+
+[Service assessments](https://www.gov.uk/service-manual/service-assessments) make sure this is reviewed and maintained at key points in delivery, for example, when moving between agile phases such as alpha and beta, or when there is a change in direction or team delivering the work.
+
+This keeps us on track to deliver services in a user-centred, secure and sustainable way.
+
+<span id="financial-management"></span>
+
+## Financial management
+
+Financial forecasts and actuals should be regularly updated and reported.
+
+This allows the delivery group to responsibly sequence spending and maintain transparency.
+
+Delivery groups should:
+
+- produce detailed forecasts for the current financial year - these should be updated monthly
+- produce actuals monthly
+- provide a high level view of spend across the delivery group
+
+<span id="working-across-defra-and-arms-length-bodies"></span>
+
+## Working across Defra and arm's length bodies
+
+Delivery groups are successful when they operate as mutually supportive partnerships across Defra group. Defra, DDTS and arm's length bodies should work collaboratively together towards achieving Defra group outcomes.
+
+To support this, delivery methods and measurements of success should be agreed as early as possible.
+
+<span id="using-this-guide"></span>
+
+## Using this guide
+
+This guide defines the minimum expectations of delivery groups. It should be used as a framework, not seen as a blocker.
+
+Delivery groups should adapt practices to context, where necessary, but as a minimum should:
+
+- link the work they are doing to the highest priority business outcomes
+- make improvements to live services every few weeks
+- keep improving the way they work
+
+### What you must maintain
+
+Delivery groups must maintain:
+
+- a link to outcomes
+- a strategic roadmap
+- an overview of services in the delivery group
+- a pipeline of work
+- monthly financial forecasts and actuals
+
+<span id="next-steps"></span>
+
+## Next steps
+
+This guide details how delivery groups should be run: aligned to outcomes, user-centred, and grounded in data and evidence.
+
+This guide only works if everyone plays their part, from strategy to delivery. When context is shared early, decisions are made at the right level and work is done transparently, it builds trust and delivers better services.
+
+If something in this guide feels unclear or doesn't fit your context, raise it. It will be improved as delivery groups learn and mature.

--- a/src/content/delivery-groups/follow-delivery-governance.md
+++ b/src/content/delivery-groups/follow-delivery-governance.md
@@ -14,7 +14,8 @@ breadcrumbs:
 ---
 
 <div class="defra-version-banner">
-  <span class="defra-version-banner__text"><span class="defra-version-banner__label" style="vertical-align: middle">Draft</span> This guide will be updated as we improve our ways of working.</span>
+  <span class="defra-version-banner__label">Draft</span>
+  <span class="defra-version-banner__text">This guide will be updated as we improve our ways of working.</span>
 </div>
 
 It sets out the minimum expectations and shared principles that delivery groups should be built on.

--- a/src/server/delivery-groups/controller.test.js
+++ b/src/server/delivery-groups/controller.test.js
@@ -75,23 +75,23 @@ describe('#deliveryGroupsController', () => {
   })
 
   describe('Tiles', () => {
-    test('should display Follow delivery governance tile with correct link', async () => {
+    test('should display Follow delivery guidance tile with correct link', async () => {
       const { result } = await server.inject({
         method: 'GET',
         url: '/delivery-groups'
       })
 
       expect(result).toEqual(
-        expect.stringContaining('Follow delivery governance')
+        expect.stringContaining('Follow delivery guidance')
       )
       expect(result).toEqual(
         expect.stringContaining(
-          'href="https://defra.github.io/delivery-group-governance/"'
+          'href="/delivery-groups/follow-delivery-governance"'
         )
       )
       expect(result).toEqual(
         expect.stringContaining(
-          'Understand the boards, approvals and reporting required'
+          'What delivery groups are, how they work, and the shared expectations'
         )
       )
     })

--- a/src/server/delivery-groups/delivery-groups.njk
+++ b/src/server/delivery-groups/delivery-groups.njk
@@ -42,9 +42,9 @@
       <li>
         <div class="defra-tile">
           <h2 class="govuk-heading-m defra-tile__title">
-            <a href="https://defra.github.io/delivery-group-governance/" class="defra-tile__link" target="_blank" rel="noreferrer noopener">Follow delivery governance</a>
+            <a href="/delivery-groups/follow-delivery-governance" class="defra-tile__link">Follow delivery guidance</a>
           </h2>
-          <p class="govuk-body defra-tile__body">Understand the boards, approvals and reporting required for your delivery group.</p>
+          <p class="govuk-body defra-tile__body">What delivery groups are, how they work, and the shared expectations for running one.</p>
         </div>
       </li>
 

--- a/src/server/markdown-pages/controller.test.js
+++ b/src/server/markdown-pages/controller.test.js
@@ -257,16 +257,18 @@ describe('#markdownPagesController', () => {
       expect(statusCode).toBe(statusCodes.ok)
     })
 
-    test('should render governance overview page with title', async () => {
+    test('should render the guidance page with title', async () => {
       const { result } = await server.inject({
         method: 'GET',
         url: '/delivery-groups/follow-delivery-governance'
       })
 
       expect(result).toEqual(
-        expect.stringContaining('Delivery group governance')
+        expect.stringContaining('Follow delivery guidance')
       )
-      expect(result).toEqual(expect.stringContaining('Governance'))
+      expect(result).toEqual(
+        expect.stringContaining('What a delivery group is')
+      )
       expect(result).toEqual(expect.stringContaining('Assurance'))
     })
 


### PR DESCRIPTION
Replace the short governance hub at /delivery-groups/follow-delivery-governance with the full "Follow delivery guidance" page, built from the delivery groups guidance document and rendered in the site's style.

- New guide content: intro, 13 sections and a Contents jump-list; keeps the governance-model and assurance sub-pages and links through to them
- Rename the landing tile to "Follow delivery guidance" and point it at the on-site page instead of the external governance site
- Add a Defra "Draft" version banner noting the guide will be updated
- Small content fixes: split the funding paragraph for emphasis, and "full lifecycle" to "full digital lifecycle"
- Update the delivery-groups and markdown-pages tests for the renamed tile and the replaced page