### PR TITLE
Fix the bouncing ReOps support email on user research pages

### DIFF
--- a/src/content/user-research.md
+++ b/src/content/user-research.md
@@ -31,7 +31,7 @@ supportBox:
   title: Get support
   description: Contact the user research operations team for further support.
   items:
-    - 'Email: <a href="mailto:DefraDDTSUserResearchOperations@defra.gov.uk" class="govuk-link">DefraDDTSUserResearchOperations@defra.gov.uk</a>'
+    - 'Email: <a href="mailto:DDTSUserResearchOperations@defra.gov.uk" class="govuk-link">DDTSUserResearchOperations@defra.gov.uk</a>'
 ---
 
 ## User researcher journey at Defra

--- a/src/content/user-research/analysis-and-synthesis.md
+++ b/src/content/user-research/analysis-and-synthesis.md
@@ -29,7 +29,7 @@ supportBox:
   title: Get support
   description: Contact the user research operations team for further support.
   items:
-    - 'Email: <a href="mailto:DefraDDTSUserResearchOperations@defra.gov.uk" class="govuk-link">DefraDDTSUserResearchOperations@defra.gov.uk</a>'
+    - 'Email: <a href="mailto:DDTSUserResearchOperations@defra.gov.uk" class="govuk-link">DDTSUserResearchOperations@defra.gov.uk</a>'
 ---
 
 <p class="govuk-body-l">Defra user researchers:</p>

--- a/src/content/user-research/recruiting-participants.md
+++ b/src/content/user-research/recruiting-participants.md
@@ -29,7 +29,7 @@ supportBox:
   title: Get support
   description: Contact the user research operations team for further support.
   items:
-    - 'Email: <a href="mailto:DefraDDTSUserResearchOperations@defra.gov.uk" class="govuk-link">DefraDDTSUserResearchOperations@defra.gov.uk</a>'
+    - 'Email: <a href="mailto:DDTSUserResearchOperations@defra.gov.uk" class="govuk-link">DDTSUserResearchOperations@defra.gov.uk</a>'
 ---
 
 ## Participant recruitment process

--- a/src/content/user-research/research-methods.md
+++ b/src/content/user-research/research-methods.md
@@ -29,7 +29,7 @@ supportBox:
   title: Get support
   description: Contact the user research operations team for further support.
   items:
-    - 'Email: <a href="mailto:DefraDDTSUserResearchOperations@defra.gov.uk" class="govuk-link">DefraDDTSUserResearchOperations@defra.gov.uk</a>'
+    - 'Email: <a href="mailto:DDTSUserResearchOperations@defra.gov.uk" class="govuk-link">DDTSUserResearchOperations@defra.gov.uk</a>'
 ---
 
 <p class="govuk-body-l">Defra user researchers:</p>

--- a/src/content/user-research/research-sessions.md
+++ b/src/content/user-research/research-sessions.md
@@ -29,7 +29,7 @@ supportBox:
   title: Get support
   description: Contact the user research operations team for further support.
   items:
-    - 'Email: <a href="mailto:DefraDDTSUserResearchOperations@defra.gov.uk" class="govuk-link">DefraDDTSUserResearchOperations@defra.gov.uk</a>'
+    - 'Email: <a href="mailto:DDTSUserResearchOperations@defra.gov.uk" class="govuk-link">DDTSUserResearchOperations@defra.gov.uk</a>'
 ---
 
 <p class="govuk-body-l">Defra user researchers:</p>

--- a/src/content/user-research/scoping-research.md
+++ b/src/content/user-research/scoping-research.md
@@ -29,7 +29,7 @@ supportBox:
   title: Get support
   description: Contact the user research operations team for further support.
   items:
-    - 'Email: <a href="mailto:DefraDDTSUserResearchOperations@defra.gov.uk" class="govuk-link">DefraDDTSUserResearchOperations@defra.gov.uk</a>'
+    - 'Email: <a href="mailto:DDTSUserResearchOperations@defra.gov.uk" class="govuk-link">DDTSUserResearchOperations@defra.gov.uk</a>'
 ---
 
 <p class="govuk-body-l">Defra user researchers:</p>

--- a/src/content/user-research/standards-and-guidance.md
+++ b/src/content/user-research/standards-and-guidance.md
@@ -29,7 +29,7 @@ supportBox:
   title: Get support
   description: Contact the user research operations team or the Defra data protection team for further support.
   items:
-    - 'User research operations: <a href="mailto:DefraDDTSUserResearchOperations@defra.gov.uk" class="govuk-link">DefraDDTSUserResearchOperations@defra.gov.uk</a>'
+    - 'User research operations: <a href="mailto:DDTSUserResearchOperations@defra.gov.uk" class="govuk-link">DDTSUserResearchOperations@defra.gov.uk</a>'
     - 'Data protection: <a href="mailto:Data.protection@defra.gov.uk" class="govuk-link">Data.protection@defra.gov.uk</a>'
 ---
 

--- a/src/content/user-research/tools.md
+++ b/src/content/user-research/tools.md
@@ -29,7 +29,7 @@ supportBox:
   title: Get support
   description: Contact the user research operations team for further support.
   items:
-    - 'Email: <a href="mailto:DefraDDTSUserResearchOperations@defra.gov.uk" class="govuk-link">DefraDDTSUserResearchOperations@defra.gov.uk</a>'
+    - 'Email: <a href="mailto:DDTSUserResearchOperations@defra.gov.uk" class="govuk-link">DDTSUserResearchOperations@defra.gov.uk</a>'
 ---
 
 Check that a tool is suitable for the data you plan to collect before you start your research. Not all approved tools can collect or store identifiable data.


### PR DESCRIPTION
The user research support email was DefraDDTSUserResearchOperations@defra.gov.uk, which bounces. This drops the stray "Defra" prefix so it reads DDTSUserResearchOperations@defra.gov.uk (one of the two correct addresses confirmed by the UR team).

- Fixed the mailto link and the visible link text on all 8 user research pages (16 occurrences)
- Verified by grep: zero instances of the old address remain