### PR TITLE
Add an experimental caveat to the AI projects pages

### DIFF
--- a/src/content/ai-toolkit/projects.md
+++ b/src/content/ai-toolkit/projects.md
@@ -31,6 +31,10 @@ supportBox:
     - 'Email: <a href="mailto:AICapabilityAndEnablement@defra.gov.uk?subject=AI%20incubator%20enquiry" class="govuk-link">AICapabilityAndEnablement@defra.gov.uk</a>'
 ---
 
+<div class="govuk-inset-text">
+  <p class="govuk-body govuk-!-margin-bottom-0">These are experiments. We are testing whether AI can help.</p>
+</div>
+
 <ul class="app-figure-cards govuk-list">
   <li class="app-stat-card">
     <span class="app-stat-card__number">34</span>

--- a/src/content/ai-toolkit/projects/checking-spending-against-policy.md
+++ b/src/content/ai-toolkit/projects/checking-spending-against-policy.md
@@ -33,6 +33,10 @@ supportBox:
     - 'Email: <a href="mailto:AICapabilityAndEnablement@defra.gov.uk?subject=Finance%20compliance%20checks" class="govuk-link">AICapabilityAndEnablement@defra.gov.uk</a>'
 ---
 
+<div class="govuk-inset-text">
+  <p class="govuk-body govuk-!-margin-bottom-0">This is an experiment. We are testing whether AI can help.</p>
+</div>
+
 <h2 class="govuk-heading-m">The problem</h2>
 
 <p class="govuk-body">Every expenses claim and every Government Procurement Card transaction has to follow policy. Someone has to check that it does.</p>

--- a/src/content/ai-toolkit/projects/content-that-needs-fixing.md
+++ b/src/content/ai-toolkit/projects/content-that-needs-fixing.md
@@ -33,6 +33,10 @@ supportBox:
     - 'Email: <a href="mailto:AICapabilityAndEnablement@defra.gov.uk?subject=Content%20quality%20checks" class="govuk-link">AICapabilityAndEnablement@defra.gov.uk</a>'
 ---
 
+<div class="govuk-inset-text">
+  <p class="govuk-body govuk-!-margin-bottom-0">This is an experiment. We are testing whether AI can help.</p>
+</div>
+
 <h2 class="govuk-heading-m">The problem</h2>
 
 <p class="govuk-body">Defra publishes a lot of content, and it keeps growing. Nobody has a clear view of what is out of date, duplicated, or no longer read.</p>

--- a/src/content/ai-toolkit/projects/guidance-easier-to-find.md
+++ b/src/content/ai-toolkit/projects/guidance-easier-to-find.md
@@ -33,6 +33,10 @@ supportBox:
     - 'Email: <a href="mailto:AICapabilityAndEnablement@defra.gov.uk?subject=RPA%20guidance" class="govuk-link">AICapabilityAndEnablement@defra.gov.uk</a>'
 ---
 
+<div class="govuk-inset-text">
+  <p class="govuk-body govuk-!-margin-bottom-0">This is an experiment. We are testing whether AI can help.</p>
+</div>
+
 <h2 class="govuk-heading-m">The problem</h2>
 
 <p class="govuk-body">We started by building a check that reviews a document before it is published. It works.</p>


### PR DESCRIPTION
Adds inset text to the projects index and the three project pages, so it is clear up front that these are experiments rather than services people can use.
